### PR TITLE
Change innerText to innerHTML for italics and formatting

### DIFF
--- a/index.js
+++ b/index.js
@@ -146,7 +146,7 @@ const inputLine = (line, k) => {
     let lineElement = document.createElement('p')
     lineElement.className = 'line'
     lineElement.id = k
-    lineElement.innerText = line
+    lineElement.innerHTML = line
     document.getElementById('speech').appendChild(lineElement)
 
 }


### PR DESCRIPTION
Allows rich text formatting by changing `innerText` to `innerHTML`